### PR TITLE
Upgrade Xerces

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -36,7 +36,7 @@
         <dependency groupid="in/jlibs" artifactid="rg-netbeans-swing-outline" version="RELEASE65"/>
         <dependency groupid="in/jlibs" artifactid="org-openide-util" version="RELEASE65"/>
         <dependency groupid="com/fifesoft" artifactid="rsyntaxtextarea" version="2.5.0"/>
-        <dependency groupid="xerces" artifactid="xercesImpl" version="2.11.0"/>
+        <dependency groupid="xerces" artifactid="xercesImpl" version="2.12.0"/>
         <dependency groupid="xml-apis" artifactid="xml-apis" version="1.4.01"/>
     </target>
 </project>

--- a/xml-nbp/pom.xml
+++ b/xml-nbp/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-            <version>2.11.0</version>
+            <version>2.12.0</version>
         </dependency>
     </dependencies>
 

--- a/xsd/pom.xml
+++ b/xsd/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-            <version>2.11.0</version>
+            <version>2.12.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
There is a security vulnerability in Xerces 2.11.0:

https://nvd.nist.gov/vuln/detail/CVE-2012-0881

This PR upgrades to 2.12.0